### PR TITLE
Add support for using alternate authentication forms

### DIFF
--- a/bitbucket/urls.py
+++ b/bitbucket/urls.py
@@ -1,4 +1,4 @@
-_BASE_URL_V1 = 'https://bitbucket.org/!api/1.0/%s'
+_BASE_URL_V1 = 'https://bitbucket.org/api/1.0/%s'
 _BASE_URL_V2 = 'https://api.bitbucket.org/2.0/%s'
 
 def request_token_url():


### PR DESCRIPTION
Allows a workflow like the following with the library (without breaking the API):
```
import requests
import keyring

bitbucket_user = '<username>'
bitbucket_password = keyring.get_password('bitbucket.org',bitbucket_user)

from bitbucket import BitBucket
bb = BitBucket(None, None, None, auth=(bitbucket_user, bitbucket_password))
c = bb.get_authorized_client(None,None)

# Check the authorization worked.
try:
    c.get_current_user()
except Exception as e:
    raise e
```
This makes the library far more useful.

I also had to fix a typo in the V1 API path, which was preventing the library from functioning at all.